### PR TITLE
Cleanup deprecated things.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,12 @@ python:
 install:
     - pip install -U setuptools==33.1.1
     - pip install zc.buildout
+    - pip install flake8
     - buildout bootstrap
     - buildout
 script:
     - bin/test -v1
+    - flake8 --doctests src setup.py
 notifications:
     email: false
 cache:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - More PEP8 compliance.
 
+- Avoid deprecation warnings by using current API.
+
 
 4.0.0 (2017-05-23)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ ignore =
     bootstrap.py
 
 [flake8]
-ignore = N801,N802,N803,N805,N806,N812,E301
+ignore = N801,N802,N803,N805,N806,N812,E301,W503
 exclude = bootstrap.py
 
 [bdist_wheel]

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,9 @@ setup(name='Products.BTreeFolder2',
       description="A BTree based implementation for Zope 2's OFS.",
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
-      long_description=(open('README.rst').read() + '\n' +
-                        open('CHANGES.rst').read()),
+      long_description=(open('README.rst').read()
+                        + '\n'
+                        + open('CHANGES.rst').read()),
       packages=find_packages('src'),
       namespace_packages=['Products'],
       package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(name='Products.BTreeFolder2',
           'Acquisition',
           'BTrees',
           'ExtensionClass>=4.1a1',
+          'future',  # for `cgi/html.escape()`
           'Persistence',
           'six',
           'Zope2 >= 4.0a5',

--- a/src/Products/BTreeFolder2/BTreeFolder2.py
+++ b/src/Products/BTreeFolder2/BTreeFolder2.py
@@ -14,7 +14,7 @@
 """BTreeFolder2
 """
 
-from cgi import escape
+from html import escape
 from logging import getLogger
 from random import randint
 import sys
@@ -190,8 +190,8 @@ class BTreeFolder2Base(Persistent):
                             % repr(key))
             return 1
         except AssertionError:
-            LOG.warn('Detected damage to %s. Fixing now.' % path,
-                     exc_info=sys.exc_info())
+            LOG.warning('Detected damage to %s. Fixing now.' % path,
+                        exc_info=sys.exc_info())
             try:
                 self._tree = OOBTree(self._tree)
                 keys = set(self._tree.keys())

--- a/src/Products/BTreeFolder2/BTreeFolder2.py
+++ b/src/Products/BTreeFolder2/BTreeFolder2.py
@@ -177,8 +177,8 @@ class BTreeFolder2Base(Persistent):
             check(self._mt_index)
             keys = set(self._tree.keys())
             for key, value in self._mt_index.items():
-                if (key not in self._mt_index or
-                        self._mt_index[key] is not value):
+                if (key not in self._mt_index
+                        or self._mt_index[key] is not value):
                     raise AssertionError(
                         "Missing or incorrect meta_type index: %s"
                         % repr(key))
@@ -205,7 +205,7 @@ class BTreeFolder2Base(Persistent):
                 new = len(keys)
                 if self._count() != new:
                     self._count.set(new)
-            except:
+            except Exception:
                 LOG.error('Failed to fix %s.' % path,
                           exc_info=sys.exc_info())
                 raise

--- a/src/Products/BTreeFolder2/tests/testBTreeFolder2.py
+++ b/src/Products/BTreeFolder2/tests/testBTreeFolder2.py
@@ -102,7 +102,7 @@ class BTreeFolder2Tests(unittest.TestCase):
         values = self.f.objectValues()
         self.assertEqual(len(values), 1)
         self.assertEqual(values[0].id, 'item')
-        self.assert_(values[0].aq_parent is self.f)
+        self.assertTrue(values[0].aq_parent is self.f)
 
     def testValues(self):
         values = self.f.values()
@@ -115,7 +115,7 @@ class BTreeFolder2Tests(unittest.TestCase):
         id, val = items[0]
         self.assertEqual(id, 'item')
         self.assertEqual(val.id, 'item')
-        self.assert_(val.aq_parent is self.f)
+        self.assertTrue(val.aq_parent is self.f)
 
     def testItems(self):
         items = self.f.items()
@@ -125,11 +125,11 @@ class BTreeFolder2Tests(unittest.TestCase):
         self.assertEqual(val.id, 'item')
 
     def testHasKey(self):
-        self.assert_(self.f.hasObject('item'))  # Old spelling
-        self.assert_(self.f.has_key('item'))  # NOQA, New spelling
+        self.assertTrue(self.f.hasObject('item'))  # Old spelling
+        self.assertTrue(self.f.has_key('item'))  # NOQA, New spelling
 
     def testContains(self):
-        self.assert_('item' in self.f)
+        self.assertTrue('item' in self.f)
 
     def testDelete(self):
         self.f._delOb('item')
@@ -138,13 +138,13 @@ class BTreeFolder2Tests(unittest.TestCase):
 
     def testDelItem(self):
         del self.f['item']
-        self.assert_('item' not in self.f)
+        self.assertTrue('item' not in self.f)
         self.assertEqual(len(self.f), 0)
 
     def testIter(self):
         iterator = iter(self.f)
         first = six.next(iterator)
-        self.assertEquals(first, 'item')
+        self.assertEqual(first, 'item')
         self.assertRaises(StopIteration, six.next, iterator)
 
     def testObjectMap(self):
@@ -166,16 +166,16 @@ class BTreeFolder2Tests(unittest.TestCase):
     def testSetObject(self):
         f2 = BTreeFolder2('item2')
         self.f._setObject(f2.id, f2)
-        self.assert_('item2' in self.f)
+        self.assertTrue('item2' in self.f)
         self.assertEqual(self.f.objectCount(), 2)
 
     def testWrapped(self):
         # Verify that the folder returns wrapped versions of objects.
         base = self.getBase(self.f._getOb('item'))
-        self.assert_(self.f._getOb('item') is not base)
-        self.assert_(self.f['item'] is not base)
-        self.assert_(self.f.get('item') is not base)
-        self.assert_(self.getBase(self.f._getOb('item')) is base)
+        self.assertTrue(self.f._getOb('item') is not base)
+        self.assertTrue(self.f['item'] is not base)
+        self.assertTrue(self.f.get('item') is not base)
+        self.assertTrue(self.getBase(self.f._getOb('item')) is base)
 
     def testGenerateId(self):
         ids = {}
@@ -201,7 +201,7 @@ class BTreeFolder2Tests(unittest.TestCase):
         old_f._setObject(inner_f.id, inner_f)
         self.ff._populateFromFolder(old_f)
         self.assertEqual(self.ff.objectCount(), 1)
-        self.assert_('inner' in self.ff)
+        self.assertTrue('inner' in self.ff)
         self.assertEqual(self.getBase(self.ff._getOb('inner')), inner_f)
 
     def testObjectListing(self):
@@ -214,26 +214,26 @@ class BTreeFolder2Tests(unittest.TestCase):
         self.assertEqual(info['b_end'], 2)
         self.assertEqual(info['prev_batch_url'], '')
         self.assertEqual(info['next_batch_url'], '')
-        self.assert_(info['formatted_list'].find('</select>') > 0)
-        self.assert_(info['formatted_list'].find('item') > 0)
-        self.assert_(info['formatted_list'].find('somefolder') > 0)
+        self.assertTrue(info['formatted_list'].find('</select>') > 0)
+        self.assertTrue(info['formatted_list'].find('item') > 0)
+        self.assertTrue(info['formatted_list'].find('somefolder') > 0)
 
         # Ensure batching is working.
         info = self.f.getBatchObjectListing({'b_count': 1})
         self.assertEqual(info['b_start'], 1)
         self.assertEqual(info['b_end'], 1)
         self.assertEqual(info['prev_batch_url'], '')
-        self.assert_(info['next_batch_url'] != '')
-        self.assert_(info['formatted_list'].find('item') > 0)
-        self.assert_(info['formatted_list'].find('somefolder') < 0)
+        self.assertTrue(info['next_batch_url'] != '')
+        self.assertTrue(info['formatted_list'].find('item') > 0)
+        self.assertTrue(info['formatted_list'].find('somefolder') < 0)
 
         info = self.f.getBatchObjectListing({'b_start': 2})
         self.assertEqual(info['b_start'], 2)
         self.assertEqual(info['b_end'], 2)
-        self.assert_(info['prev_batch_url'] != '')
+        self.assertTrue(info['prev_batch_url'] != '')
         self.assertEqual(info['next_batch_url'], '')
-        self.assert_(info['formatted_list'].find('item') < 0)
-        self.assert_(info['formatted_list'].find('somefolder') > 0)
+        self.assertTrue(info['formatted_list'].find('item') < 0)
+        self.assertTrue(info['formatted_list'].find('somefolder') > 0)
 
     def testObjectListingWithSpaces(self):
         # The option list must use value attributes to preserve spaces.
@@ -243,24 +243,24 @@ class BTreeFolder2Tests(unittest.TestCase):
         self.f.absolute_url = lambda: ''
         info = self.f.getBatchObjectListing()
         expect = '<option value="%s">%s</option>' % (name, name)
-        self.assert_(info['formatted_list'].find(expect) > 0)
+        self.assertTrue(info['formatted_list'].find(expect) > 0)
 
     def testCleanup(self):
-        self.assert_(self.f._cleanup())
+        self.assertTrue(self.f._cleanup())
         key = TrojanKey('a')
         self.f._tree[key] = 'b'
-        self.assert_(self.f._cleanup())
+        self.assertTrue(self.f._cleanup())
         key.value = 'z'
 
         # With a key in the wrong place, there should now be damage.
-        self.assert_(not self.f._cleanup())
+        self.assertTrue(not self.f._cleanup())
         # Now it's fixed.
-        self.assert_(self.f._cleanup())
+        self.assertTrue(self.f._cleanup())
 
         from BTrees.OIBTree import OIBTree
         tree = self.f._mt_index['d'] = OIBTree()
         tree['e'] = 1
-        self.assert_(not self.f._cleanup())
+        self.assertTrue(not self.f._cleanup())
 
         # Verify the management interface also works,
         # but don't test return values.

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist =
    py27,
    py34,
    py35,
-   py36
+   py36,
+   flake8,
 
 [testenv]
 commands =
@@ -14,3 +15,8 @@ skip_install = true
 deps =
     setuptools==33.1.1
     zc.buildout
+
+[testenv:flake8]
+basepython = python3.6
+deps = flake8
+commands = flake8 --doctests src tests setup.py


### PR DESCRIPTION
As in zopefoundation/Zope/issues/268, we want to clean up `DeprecationWarnings`.

The additional dependency of `future` seems hard to avoid and might also be handy in other zope projects.